### PR TITLE
Use x_window by default for non-windows systems

### DIFF
--- a/source/platform/min/window.h
+++ b/source/platform/min/window.h
@@ -24,7 +24,7 @@ namespace min
 using window = min::win32_window;
 }
 
-#elif __linux__
+#else
 
 #include <min/x_window.h>
 


### PR DESCRIPTION
`x_window` would be the thing to use not just on linux, but on most unix systems, including at least all BSDs and probably macos, so use it by default.